### PR TITLE
Post's title and Tag's label lenght reduced for mysql backward compatibility

### DIFF
--- a/src/Blog/Entity/Post.php
+++ b/src/Blog/Entity/Post.php
@@ -42,7 +42,7 @@ class Post
     private string $slug;
 
     /**
-     * @Column(type="string(255)", default="")
+     * @Column(type="string(191)", default="")
      */
     private string $title = '';
 

--- a/src/Blog/Entity/Tag.php
+++ b/src/Blog/Entity/Tag.php
@@ -28,7 +28,7 @@ class Tag
     private ?int $id = null;
 
     /**
-     * @Column(type="string(255)")
+     * @Column(type="string(191)")
      */
     private string $label;
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | https://github.com/yiisoft/demo/issues/358
