### PR TITLE
Raise symfony/console dependency version to "^5.3"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "psr/http-server-middleware": "^1.0",
         "psr/log": "^1.1",
         "spiral/database": "^2.8",
-        "symfony/console": "^5.2",
+        "symfony/console": "^5.3",
         "vlucas/phpdotenv": "^5.3",
         "yiisoft/access": "^1.0",
         "yiisoft/aliases": "^2.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -
