### PR TITLE
fix: symfony/console 6.1.1 require php >8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "psr/http-server-handler": "^1.0",
         "psr/http-server-middleware": "^1.0",
         "psr/log": "^3.0",
-        "symfony/console": "^6.0",
+        "symfony/console": "<6.1.0",
         "vlucas/phpdotenv": "^5.3",
         "yiisoft/access": "^1.0",
         "yiisoft/aliases": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "psr/http-server-handler": "^1.0",
         "psr/http-server-middleware": "^1.0",
         "psr/log": "^3.0",
-        "symfony/console": "<6.1.0",
+        "symfony/console": "^5.4|^6.0",
         "vlucas/phpdotenv": "^5.3",
         "yiisoft/access": "^1.0",
         "yiisoft/aliases": "^2.0",


### PR DESCRIPTION
fix #474

https://github.com/symfony/console/commit/921378e9d9485dbeab330809b74b0aa50df0b7fc