### PR TITLE
Creating cookie _language for HTTP

### DIFF
--- a/src/Middleware/LocaleMiddleware.php
+++ b/src/Middleware/LocaleMiddleware.php
@@ -42,7 +42,8 @@ final class LocaleMiddleware implements MiddlewareInterface
         SessionInterface $session,
         LoggerInterface $logger,
         ResponseFactoryInterface $responseFactory,
-        array $locales = []
+        array $locales = [],
+        private bool $cookieSecure = false
     ) {
         $this->translator = $translator;
         $this->urlGenerator = $urlGenerator;
@@ -159,7 +160,7 @@ final class LocaleMiddleware implements MiddlewareInterface
     {
         $this->logger->info('Saving found locale to cookies');
         $this->session->set($this->sessionName, $locale);
-        $cookie = (new Cookie($this->sessionName, $locale));
+        $cookie = (new Cookie($this->sessionName, $locale, secure: $this->cookieSecure));
         if ($this->cookieDuration !== null) {
             $cookie = $cookie->withMaxAge($this->cookieDuration);
         }
@@ -216,6 +217,12 @@ final class LocaleMiddleware implements MiddlewareInterface
     {
         $new = clone $this;
         $new->enableDetectLocale = $enableDetectLocale;
+        return $new;
+    }
+
+    public function withCookieSecure(bool $secure) : self {
+        $new = clone $this;
+        $new->cookieSecure = $secure;
         return $new;
     }
 }


### PR DESCRIPTION
1. create host `127.0.0.1 kubernetes.docker.internal`
2. open http://kubernetes.docker.internal:8080/ru/ for RU language
3. Open http://kubernetes.docker.internal:8080/ 

### What is the expected result?
RU language

### What do you get instead?
default language EN

cookie _language missed
![image](https://user-images.githubusercontent.com/874234/181836841-b4b3655e-3dad-48c1-9a31-9371b6cc1b80.png)


PS
Disabled Secure attribute of cookie for _language
https://web.dev/when-to-use-local-https/#use-http:localhost-by-default
