### PR TITLE
Psalm Level 6 Testing:

### DIFF
--- a/src/Blog/Post/PostController.php
+++ b/src/Blog/Post/PostController.php
@@ -55,7 +55,7 @@ final class PostController
                 return $this->webService->getRedirectResponse('blog/index');
             }
 
-            $parameters['errors'] = $form->getFirstErrors();
+            $parameters['errors'] = $form->getFormErrors();
         }
 
         return $this->viewRenderer->render('__form', $parameters);


### PR DESCRIPTION
Change $form->getFirstErrors()  to $form->getFormErrors()

ERROR: UndefinedMethod - src/Blog/Post/PostController.php:58:44 - Method App\Blog\Post\PostForm::getFirstErrors does not exist (see https://psalm.dev/022)
            $parameters['errors'] = $form->getFirstErrors();

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | Change $form->getFirstErrors()  to $form->getFormErrors()
