### PR TITLE
fix: Timeout for ".\yii serve"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -109,7 +109,10 @@
         }
     },
     "scripts": {
-        "serve": "./yii serve",
+        "serve": [
+            "Composer\\Config::disableProcessTimeout",
+            "./yii serve"
+        ],
         "post-update-cmd": [
             "App\\Installer::postUpdate",
             "App\\Installer::copyEnvFile"


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  |  To fix The process ".\yii serve" exceeded the timeout of 300 seconds.

![image](https://user-images.githubusercontent.com/874234/196526045-e081393a-021e-434e-94b9-dc905fa8fa9a.png)

P.S. see https://getcomposer.org/doc/06-config.md#process-timeout