### PR TITLE
Update OffsetPagination.php

### DIFF
--- a/blog/src/Widget/OffsetPagination.php
+++ b/blog/src/Widget/OffsetPagination.php
@@ -78,8 +78,8 @@ final class OffsetPagination extends Widget
         if ($this->prepared) {
             return;
         }
-        $this->pagesCount = $this->paginator->getTotalPages();
-        $this->currentPage = $this->paginator->getCurrentPage();
+        $this->pagesCount = null!== $this->paginator ? $this->paginator->getTotalPages() : 0;
+        $this->currentPage = null!== $this->paginator ? $this->paginator->getCurrentPage() : 0;
         if ($this->pagesCount > 9) {
             if ($this->currentPage <= 4) {
                 $this->pages = [...range(1, 5), null, ...range($this->pagesCount - 2, $this->pagesCount)];
@@ -109,7 +109,7 @@ final class OffsetPagination extends Widget
         $result = '';
 
         // `Previous` page
-        $prevUrl = $this->paginator->isOnFirstPage() ? null : $this->getPageLink($this->currentPage - 1);
+        $prevUrl = null!==$this->paginator && $this->paginator->isOnFirstPage() ? null : $this->getPageLink($this->currentPage - 1);
         $result .= Html::openTag('li', ['class' => $prevUrl === null ? 'page-item disabled' : 'page-item']);
         $result .= Html::a('Previous', $prevUrl, ['class' => 'page-link']);
         $result .= Html::closeTag('li');
@@ -127,7 +127,7 @@ final class OffsetPagination extends Widget
         }
 
         // `Next` page
-        $nextUrl = $this->paginator->isOnLastPage() ? null : $this->getPageLink($this->currentPage + 1);
+        $nextUrl = null!==$this->paginator && $this->paginator->isOnLastPage() ? null : $this->getPageLink($this->currentPage + 1);
         $result .= Html::openTag('li', ['class' => $nextUrl === null ? 'page-item disabled' : 'page-item']);
         $result .= Html::a('Next', $nextUrl, ['class' => 'page-link']);
         $result .= Html::closeTag('li');


### PR DESCRIPTION
C:\wamp64\www\yii3-i-4>php ./vendor/bin/psalm src/Widget/OffsetPagination.php Target PHP version: 8.1 (inferred from composer.json) Extensions enabled:  (unsupported extensions: mbstring, pdo_sqlite, gd, intl, openssl) Scanning files...
Analyzing files...

E

ERROR: PossiblyNullReference - src/Widget/OffsetPagination.php:81:47 - Cannot call method getTotalPages on possibly null value (see https://psalm.dev/083)
        $this->pagesCount = $this->paginator->getTotalPages();


ERROR: PossiblyNullReference - src/Widget/OffsetPagination.php:112:38 - Cannot call method isOnFirstPage on possibly null value (see https://psalm.dev/083)
        $prevUrl = $this->paginator->isOnFirstPage() ? null : $this->getPageLink($this->currentPage - 1);


------------------------------
2 errors found
------------------------------
4 other issues found.
You can display them with --show-info=true
------------------------------

Checks took 4.15 seconds and used 579.459MB of memory Psalm was able to infer types for 95.5134% of the codebase

C:\wamp64\www\yii3-i-4>php ./vendor/bin/psalm src/Widget/OffsetPagination.php Target PHP version: 8.1 (inferred from composer.json) Extensions enabled:  (unsupported extensions: mbstring, pdo_sqlite, gd, intl, openssl) Scanning files...
Analyzing files...

E

ERROR: PossiblyNullReference - src/Widget/OffsetPagination.php:82:48 - Cannot call method getCurrentPage on possibly null value (see https://psalm.dev/083)
        $this->currentPage = $this->paginator->getCurrentPage();


ERROR: PossiblyNullReference - src/Widget/OffsetPagination.php:112:38 - Cannot call method isOnFirstPage on possibly null value (see https://psalm.dev/083)
        $prevUrl = $this->paginator->isOnFirstPage() ? null : $this->getPageLink($this->currentPage - 1);


------------------------------
2 errors found
------------------------------
4 other issues found.
You can display them with --show-info=true
------------------------------

Checks took 4.21 seconds and used 579.468MB of memory Psalm was able to infer types for 95.5136% of the codebase

C:\wamp64\www\yii3-i-4>php ./vendor/bin/psalm src/Widget/OffsetPagination.php Target PHP version: 8.1 (inferred from composer.json) Extensions enabled:  (unsupported extensions: mbstring, pdo_sqlite, gd, intl, openssl) Scanning files...
Analyzing files...

E

ERROR: PossiblyNullReference - src/Widget/OffsetPagination.php:130:38 - Cannot call method isOnLastPage on possibly null value (see https://psalm.dev/083)
        $nextUrl = $this->paginator->isOnLastPage() ? null : $this->getPageLink($this->currentPage + 1);


------------------------------
1 errors found
------------------------------
4 other issues found.
You can display them with --show-info=true
------------------------------

Checks took 4.16 seconds and used 580.706MB of memory Psalm was able to infer types for 95.5140% of the codebase

C:\wamp64\www\yii3-i-4>php ./vendor/bin/psalm src/Widget/OffsetPagination.php Target PHP version: 8.1 (inferred from composer.json) Extensions enabled:  (unsupported extensions: mbstring, pdo_sqlite, gd, intl, openssl) Scanning files...
Analyzing files...

░

------------------------------

       No errors found!

------------------------------

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️/❌
| New feature?  | ✔️/❌
| Breaks BC?    | ✔️/❌
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
