### PR TITLE
Fixed `schema-providers` configuration

### DIFF
--- a/blog-api/composer.json
+++ b/blog-api/composer.json
@@ -49,7 +49,7 @@
         "yiisoft/factory": "^1.0",
         "yiisoft/files": "^2.0",
         "yiisoft/http": "^1.2",
-        "yiisoft/hydrator-validator": "dev-master",
+        "yiisoft/hydrator-validator": "^1.0",
         "yiisoft/injector": "^1.0",
         "yiisoft/input-http": "dev-master",
         "yiisoft/log": "^2.0",

--- a/blog-api/config/common/params.php
+++ b/blog-api/config/common/params.php
@@ -5,12 +5,13 @@ declare(strict_types=1);
 use App\Queue\LoggingAuthorizationHandler;
 use Cycle\Database\Config\SQLite\FileConnectionConfig;
 use Cycle\Database\Config\SQLiteDriverConfig;
+use Cycle\Schema\Provider\SchemaProviderInterface;
+use Cycle\Schema\Provider\PhpFileSchemaProvider;
+use Cycle\Schema\Provider\Support\SchemaProviderPipeline;
 use Yiisoft\ErrorHandler\Middleware\ErrorCatcher;
 use Yiisoft\Router\Middleware\Router;
 use Yiisoft\Yii\Cycle\Schema\Conveyor\AttributedSchemaConveyor;
 use Yiisoft\Yii\Cycle\Schema\Provider\FromConveyorSchemaProvider;
-use Yiisoft\Yii\Cycle\Schema\Provider\PhpFileSchemaProvider;
-use Yiisoft\Yii\Cycle\Schema\SchemaProviderInterface;
 use Yiisoft\Yii\Middleware\Locale;
 use Yiisoft\Yii\Middleware\Subfolder;
 use Yiisoft\Yii\Queue\Adapter\SynchronousAdapter;
@@ -87,7 +88,7 @@ return [
         ],
 
         /**
-         * SchemaProvider list for {@see \Yiisoft\Yii\Cycle\Schema\Provider\Support\SchemaProviderPipeline}
+         * SchemaProvider list for {@see SchemaProviderPipeline}
          * Array of classname and {@see SchemaProviderInterface} object.
          * You can configure providers if you pass classname as key and parameters as array:
          * [
@@ -106,7 +107,7 @@ return [
          */
         'schema-providers' => [
             // Uncomment next line to enable a Schema caching in the common cache
-            // \Yiisoft\Yii\Cycle\Schema\Provider\SimpleCacheSchemaProvider::class => ['key' => 'cycle-orm-cache-key'],
+            // \Cycle\Schema\Provider\SimpleCacheSchemaProvider::class => ['key' => 'cycle-orm-cache-key'],
 
             // Store generated Schema in the file
             PhpFileSchemaProvider::class => [


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌

1. Changed namespaces in the configuration file of the `yiisoft/yii-cycle` package. Related to: https://github.com/yiisoft/yii-cycle/pull/186
2. Added stable version of `yiisoft/hydrator-validator`. To fix dependency installation error:

```
 Problem 1
    - Root composer.json requires yiisoft/input-http dev-master -> satisfiable by yiisoft/input-http[dev-master].
    - yiisoft/input-http dev-master requires yiisoft/hydrator-validator ^1.0 -> found yiisoft/hydrator-validator[1.0.0] but it conflicts with your root composer.json require (dev-master).
  Problem 2
    - yiisoft/input-http dev-master requires yiisoft/hydrator-validator ^1.0 -> found yiisoft/hydrator-validator[1.0.0] but it conflicts with your root composer.json require (dev-master).
    - yiisoft/yii-gii dev-master requires yiisoft/input-http dev-master -> satisfiable by yiisoft/input-http[dev-master].
    - Root composer.json requires yiisoft/yii-gii dev-master -> satisfiable by yiisoft/yii-gii[dev-master].

```